### PR TITLE
Include default css in the binary so it works outside the repo dir

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,8 +1,9 @@
 use pulldown_cmark::{html, Options, Parser};
+use std::error::Error;
 use std::fs;
 use std::fs::File;
-use std::io::{self, prelude::*};
-use std::error::Error;
+use std::io::prelude::*;
+use std::path::Path;
 
 pub fn markdown_to_html(input_contents: &str) -> String {
     let options = Options::empty();
@@ -13,6 +14,14 @@ pub fn markdown_to_html(input_contents: &str) -> String {
 }
 
 pub fn write_to_file(html_output: String, output_filename: &str) -> Result<(), Box<dyn Error>> {
+    // If we are in the git repo or someone has provided a css file near their working directory we can use that.
+    // Otherwise use the one included at compile time.
+    let css = if Path::new("styles/style.css").exists() {
+        fs::read_to_string("styles/style.css")?
+    } else {
+        DEFAULT_CSS.to_string()
+    };
+
     let precontent = format!(
         r#"<html lang="en">
         <head>
@@ -25,7 +34,7 @@ pub fn write_to_file(html_output: String, output_filename: &str) -> Result<(), B
         <body>
             <div id='content'>"#,
         output_filename.replace(".md", ""),
-        fs::read_to_string("styles/style.css")?,
+        css,
     );
     let postcontent = r#"
             </div>
@@ -35,3 +44,7 @@ pub fn write_to_file(html_output: String, output_filename: &str) -> Result<(), B
     write!(output_file, "{}{}{}", precontent, html_output, postcontent)?;
     Ok(())
 }
+
+// Include the default css at compile time so it doesn't matter where the binary ends up it will always be able to find
+// this file.
+const DEFAULT_CSS: &str = include_str!("../styles/style.css");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
 use std::error::Error;
-use std::fs::File;
-use std::io::{self, prelude::*};
-use std::env;
 
 mod args;
 mod convert;
@@ -13,6 +10,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let html_output = convert::markdown_to_html(&input_contents);
     let output_filename = args.input_filename.replace(".md", ".html");
     convert::write_to_file(html_output, &output_filename)?;
-    println!("Succesfully converted!");
+    println!("Successfully converted!");
     Ok(())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,6 @@
-use pulldown_cmark::{html, Options, Parser};
-use std::fs::File;
-use std::io::{self, prelude::*};
 use std::error::Error;
+use std::fs::File;
+use std::io::prelude::*;
 
 pub fn parse_file(input_filename: &str) -> Result<String, Box<dyn Error>> {
     let mut input_file = File::open(input_filename)?;


### PR DESCRIPTION
When following the instructions in the readme to use cargo install, and then running the `makurust` command where your markdown file is, an error is generated:

```
Error: Os { code: 3, kind: NotFound, message: "The system cannot find the path specified." }
```

This comes from the part where the css file is baked into the html file and is caused by the current working directory not being the root of the project so it can't find the expected `style.css`

I solved this by using the `include_file!` macro to create a constant with the default css. If running from the repo or a user puts a `styles/style.css` file next to their markdown file it will use that. Otherwise it will fall back to the default one included inside the binary.

(I also cleaned up a few unused import warnings)